### PR TITLE
dashboard-list.js sorts dashboards and updates page-header

### DIFF
--- a/client/app/pages/dashboards/dashboard-list.js
+++ b/client/app/pages/dashboards/dashboard-list.js
@@ -39,6 +39,7 @@ function DashboardListCtrl(Dashboard, $location, clientConfig) {
   this.dashboards.$promise.then((data) => {
     const out = data.map(dashboard => dashboard.name.match(TAGS_REGEX));
     this.allTags = _.unique(_.flatten(out)).filter(e => e).map(tag => tag.replace(/:$/, ''));
+    this.allTags.sort();
   });
 
   this.paginator = new Paginator([], { page });
@@ -82,6 +83,7 @@ export default function (ngModule) {
   const route = {
     template: '<page-dashboard-list></page-dashboard-list>',
     reloadOnSearch: false,
+    title: 'Dashboards',
   };
 
   return {


### PR DESCRIPTION
Two simple changes to dashboard-list.js

1. Have the list of Dashboards sorted in alphabetical order via allTags.sort();
2. Fix page-header not updating bug by adding in title: 'Dashboards' in the route

